### PR TITLE
Fix recipe loading dependency

### DIFF
--- a/src/hooks/useProductionOrder.ts
+++ b/src/hooks/useProductionOrder.ts
@@ -52,25 +52,23 @@ export default function useProductionOrder({ id, calendarItems, calendarDate }: 
   useEffect(() => {
     const loadRecipes = async () => {
       if (authLoading || !activeCompany?.id) {
-        console.error("Empresa ativa não carregada");
-        toast.error("Empresa ativa não carregada");
-        setLoading(false);
-        return;
+        return; // Aguarda empresa ativa carregar
       }
+
       setLoading(true);
       const recipesData = await getRecipes(activeCompany.id);
       setRecipes(recipesData);
-      
+
       // If we have an ID, load the production order
       if (id) {
         await loadProductionOrder(id);
       }
-      
+
       setLoading(false);
     };
-    
+
     loadRecipes();
-  }, [id]);
+  }, [id, activeCompany?.id, authLoading]);
   
   useEffect(() => {
     // Detect if navigation came from calendar


### PR DESCRIPTION
## Summary
- ensure recipes load when company data is available

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68409457632083338dc7c37101bd3c97