### PR TITLE
Fix data load triggers for auth and company context

### DIFF
--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -119,7 +119,7 @@ export function useDashboardData() {
     };
     
     fetchDashboardData();
-  }, []);
+  }, [activeCompany?.id, authLoading]);
 
   return { loading, dashboardStats, recentActivity };
 }

--- a/src/hooks/useProductionOrder.ts
+++ b/src/hooks/useProductionOrder.ts
@@ -70,7 +70,7 @@ export default function useProductionOrder({ id, calendarItems, calendarDate }: 
     };
     
     loadRecipes();
-  }, [id]);
+  }, [id, activeCompany?.id, authLoading]);
   
   useEffect(() => {
     // Detect if navigation came from calendar

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -183,28 +183,30 @@ function Products() {
   };
 
   useEffect(() => {
-    fetchProducts();
-    fetchGroups();
-    fetchSubgroups();
-    fetchSetores();
+    if (!authLoading && activeCompany?.id) {
+      fetchProducts();
+      fetchGroups();
+      fetchSubgroups();
+      fetchSetores();
 
-    // Configurar intervalo de atualização automática
-    refreshTimerRef.current = setInterval(() => {
-      console.log("Atualizando produtos automaticamente...");
-      // Não atualizar se o diálogo de edição estiver aberto para evitar conflitos
-      if (!editOpen) {
-        fetchProducts();
-      } else {
-        console.log("Atualizacao automática pulada - diálogo de edição aberto");
-      }
-    }, 5 * 60 * 1000);
+      // Configurar intervalo de atualização automática
+      refreshTimerRef.current = setInterval(() => {
+        console.log("Atualizando produtos automaticamente...");
+        // Não atualizar se o diálogo de edição estiver aberto para evitar conflitos
+        if (!editOpen) {
+          fetchProducts();
+        } else {
+          console.log("Atualizacao automática pulada - diálogo de edição aberto");
+        }
+      }, 5 * 60 * 1000);
+    }
 
     return () => {
       if (refreshTimerRef.current) {
         clearInterval(refreshTimerRef.current);
       }
     };
-  }, [editOpen]); // Adicionar editOpen como dependência
+  }, [editOpen, activeCompany?.id, authLoading]);
 
   useEffect(() => {
     if (selectedProduct) {

--- a/src/pages/Recipes.tsx
+++ b/src/pages/Recipes.tsx
@@ -110,10 +110,12 @@ export default function Recipes() {
   };
   
   useEffect(() => {
-    fetchRecipes();
-    fetchGroups();
-    fetchSubgroups();
-  }, []);
+    if (!authLoading && activeCompany?.id) {
+      fetchRecipes();
+      fetchGroups();
+      fetchSubgroups();
+    }
+  }, [activeCompany?.id, authLoading]);
   
   // Filtrar subgrupos com base no grupo selecionado
   useEffect(() => {


### PR DESCRIPTION
## Summary
- reload dashboard when company finishes loading
- refresh products, groups and sets when company context changes
- load production orders only after auth and company ready
- refetch recipes once auth and company are loaded

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68409c2530048333a567a5c80301bc37