### PR TITLE
Fix BadgeProps children field

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -25,7 +25,9 @@ const badgeVariants = cva(
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+    VariantProps<typeof badgeVariants> {
+  children?: React.ReactNode
+}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (


### PR DESCRIPTION
## Summary
- fix BadgeProps to include children prop

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: many missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68431a76f70883339dd53a2230fb967a